### PR TITLE
Fix tmux quit warning logic bug

### DIFF
--- a/lua/custom/options.lua
+++ b/lua/custom/options.lua
@@ -53,7 +53,7 @@ vim.api.nvim_create_autocmd('VimLeavePre', {
         2
       )
       if choice ~= 1 then
-        vim.cmd('cquit!')
+        return
       end
     end
   end,


### PR DESCRIPTION
Replace `cquit!` with `return` when user chooses 'No' to properly
prevent nvim from quitting in shared tmux sessions.

Previously, clicking 'No' would still force quit nvim due to the
inverted logic using `cquit!` command.

Resolves #8
