### PR TITLE
Improve tmux shared session detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ A modular Neovim configuration forked from [kickstart.nvim](https://github.com/n
 
 ## Development Commands
 
+### Testing Configuration Changes
+- **`nvdev`** - Launch Neovim with isolated test configuration
+  - Completely separate from regular nvim (uses `NVIM_APPNAME="nvim-custom"`)
+  - All data/cache/state redirected to project directory
+  - Logs saved to `.local/state/nvim-launch.log`
+  - **Use this to verify any configuration changes before committing**
+  - Example: `nvdev` to test, `nvdev somefile.lua` to test with a specific file
+
 ### Plugin Management
 - `:Lazy` - Open plugin manager UI
 - `:Lazy reload` - Reload plugin configurations
@@ -113,6 +121,7 @@ A modular Neovim configuration forked from [kickstart.nvim](https://github.com/n
 - **Add new plugin**: Create file in `lua/custom/plugins/`, add import to `lua/custom/plugins/init.lua`
 - **Update LSP config**: Edit `lua/custom/plugins/lsp/lsp.lua`
 - **Change keybindings**: Edit `lua/custom/keymaps.lua`
+- **Visual/UI changes**: After Claude tests with `nvdev`, dlond will verify GUI elements (colors, themes, visual plugins)
 - **Update from upstream kickstart**: 
   ```bash
   git fetch kickstart

--- a/lua/custom/options.lua
+++ b/lua/custom/options.lua
@@ -33,6 +33,12 @@ local function is_shared_tmux_session()
   local output = handle:read('*a')
   handle:close()
   
+  -- Check if session name contains "shared" (case insensitive)
+  if current_session:lower():find('shared') then
+    return true
+  end
+  
+  -- Also check if multiple users are attached
   for line in output:gmatch('[^\r\n]+') do
     local session_name, attached_count = line:match('([^:]+):(%d+)')
     if session_name == current_session and tonumber(attached_count) > 1 then
@@ -50,10 +56,12 @@ vim.api.nvim_create_autocmd('VimLeavePre', {
       local choice = vim.fn.confirm(
         'You are in a shared tmux session. Other users may be affected.\nDo you really want to quit?',
         '&Yes\n&No',
-        2
+        2  -- Default to No
       )
+      -- vim.fn.confirm returns 1 for Yes, 2 for No, 0 for Esc
+      -- The & makes Y/y and N/n work as shortcuts (case-insensitive)
       if choice ~= 1 then
-        return
+        return  -- Prevent quit unless explicitly choosing Yes
       end
     end
   end,


### PR DESCRIPTION
- Add case-insensitive check for 'shared' in session name
- Keep existing check for multiple attached clients
- Add documentation about vim.fn.confirm() keyboard shortcuts
- Update CLAUDE.md with nvdev testing workflow

This ensures the quit warning triggers for any session with 'shared'
in the name, not just sessions with multiple attachments.

Fixes #21

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>
