### PR TITLE
feat: complete LSP and formatter configuration

### DIFF
--- a/.tmuxp.nvim.half.json
+++ b/.tmuxp.nvim.half.json
@@ -1,0 +1,14 @@
+{
+  "session_name": "nvim",
+  "tmux_options": "-f /Users/dlond/.config/tmux/tmux.conf",
+  "windows": [
+    {
+      "window_name": "editor",
+      "layout": "even-vertical",
+      "panes": [
+        { "shell_command": ["nvim ."] },
+        { "shell_command": [] }
+      ]
+    }
+  ]
+}

--- a/lua/plugins/config/lsp/servers.lua
+++ b/lua/plugins/config/lsp/servers.lua
@@ -67,16 +67,21 @@ function M.get_servers()
           analysis = {
             autoSearchPaths = true,
             diagnosticMode = 'openFilesOnly',
-            typeCheckingMode = 'standard',
+            typeCheckingMode = 'basic',
             useLibraryCodeForTypes = true,
 
             diagnosticSeverityOverrides = {
               reportOptionalCall = 'none',
               reportOptionalSubscript = 'none',
+              reportOptionalMemberAccess = 'none',
+              reportOptionalIterable = 'none',
               reportAttributeAccessIssue = 'none',
-              reportUnknownMemberType = 'warning',
-              reportUnknownVariableType = 'warning',
-              reportUnknownAssignmentType = 'warning',
+              reportUnknownMemberType = 'none',
+              reportUnknownVariableType = 'none',
+              reportUnknownArgumentType = 'none',
+              reportUnknownParameterType = 'none',
+              reportUnknownAssignmentType = 'none',
+              reportMissingTypeStubs = 'none',
             },
           },
         },
@@ -98,6 +103,41 @@ function M.get_servers()
       filetypes = { 'cmake' },
       root_dir = util.root_pattern('CMakeLists.txt', '.git'),
     },
+
+    -- Lua Language Server
+    lua_ls = {
+      settings = {
+        Lua = {
+          runtime = { version = 'LuaJIT' },
+          diagnostics = {
+            globals = { 'vim' },
+          },
+          workspace = {
+            library = vim.api.nvim_get_runtime_file('', true),
+            checkThirdParty = false,
+          },
+          telemetry = { enable = false },
+        },
+      },
+    },
+
+    -- Bash Language Server
+    bashls = {},
+
+    -- YAML Language Server
+    yamlls = {},
+
+    -- JSON Language Server
+    jsonls = {},
+
+    -- Markdown Language Server
+    marksman = {},
+
+    -- TOML Language Server
+    taplo = {},
+
+    -- SQL Language Server
+    sqls = {},
 
     -- Add more servers here as needed
     -- Example:

--- a/lua/plugins/spec/formatting.lua
+++ b/lua/plugins/spec/formatting.lua
@@ -1,40 +1,40 @@
 -- Formatter configuration
 
 return {
-    -- ========================================
-    -- Formatter Configuration (conform.nvim)
-    -- ========================================
-    {
-        'stevearc/conform.nvim',
-        event = 'BufWritePre', -- Format on save
-        -- cmd = { 'ConformInfo' }, -- Optional: If you want the command available
-        -- keys = { ... } -- Optional: Define keys if needed
-        opts = {
-            formatters_by_ft = {
-                lua = { 'stylua' },
-                c = { 'clang_format' },
-                cpp = { 'clang_format' },
-                -- Use ruff for Python formatting (includes isort and is faster than black
-                -- Ensure 'ruff' is installed via Home Manager (pkgs.ruff)
-                python = { 'ruff_format', 'ruff_fix' },
-                -- python = { 'isort', 'black' },
-                nix = { 'alejandra' }, -- Add nix formatter
-                -- Add other filetypes and formatters, e.g.:
-                -- javascript = { "prettier" },
-                -- typescript = { "prettier" },
-                -- css = { "prettier" },
-                -- html = { "prettier" },
-                -- json = { "prettier" },
-                -- yaml = { "prettier" },
-                -- markdown = { "prettier" },
-                -- bash = { "shfmt" },
-            },
-            -- Configure format_on_save behavior
-            format_on_save = {
-                -- I recommend these options, but adjust to your liking
-                timeout_ms = 500,    -- Stop formatting if it takes too long
-                lsp_fallback = true, -- Fallback to LSP formatting if conform fails
-            },
-        },
+  -- ========================================
+  -- Formatter Configuration (conform.nvim)
+  -- ========================================
+  {
+    'stevearc/conform.nvim',
+    event = 'BufWritePre', -- Format on save
+    -- cmd = { 'ConformInfo' }, -- Optional: If you want the command available
+    -- keys = { ... } -- Optional: Define keys if needed
+    opts = {
+      formatters_by_ft = {
+        lua = { 'stylua' },
+        c = { 'clang_format' },
+        cpp = { 'clang_format' },
+        python = { 'ruff_organize_imports', 'ruff_format', 'ruff_fix' },
+        nix = { 'alejandra' }, -- Add nix formatter
+        -- Add other filetypes and formatters, e.g.:
+        javascript = { 'prettier' },
+        typescript = { 'prettier' },
+        css = { 'prettier' },
+        html = { 'prettier' },
+        json = { 'prettier' },
+        yaml = { 'prettier' },
+        markdown = { 'prettier' },
+        bash = { 'shfmt' },
+        sh = { 'shfmt' },
+        cmake = { 'cmake_format' },
+        sql = { 'sqlfluff' },
+      },
+      -- Configure format_on_save behavior
+      format_on_save = {
+        -- I recommend these options, but adjust to your liking
+        timeout_ms = 500, -- Stop formatting if it takes too long
+        lsp_fallback = true, -- Fallback to LSP formatting if conform fails
+      },
     },
+  },
 }


### PR DESCRIPTION
  - Add missing LSPs: lua_ls, bashls, yamlls, jsonls, marksman, taplo, sqls
  - Add missing formatters: prettier, shfmt, sqlfluff, cmake_format
  - Configure ruff with import organization and auto-fixes
  - Tune basedpyright to reduce diagnostic noise (basic mode)

  All LSPs verified attaching and formatters working correctly.
