### PR TITLE
fix: use markdown_oxide LSP instead of marksman

### DIFF
--- a/lua/plugins/config/lsp/servers.lua
+++ b/lua/plugins/config/lsp/servers.lua
@@ -130,8 +130,8 @@ function M.get_servers()
     -- JSON Language Server
     jsonls = {},
 
-    -- Markdown Language Server
-    marksman = {},
+    -- Markdown Language Server (Rust-based, avoids .NET build issues)
+    markdown_oxide = {},
 
     -- TOML Language Server
     taplo = {},


### PR DESCRIPTION
- Switch from marksman to markdown_oxide to match system-flakes change
- Avoids .NET build issues on macOS ARM
- markdown_oxide is Rust-based with better caching

Related: dlond/system-flakes#182
Fixes #53
